### PR TITLE
Add rec.2020

### DIFF
--- a/lch/index.html
+++ b/lch/index.html
@@ -55,6 +55,11 @@
 			<div class="out-of-gamut-warning">Out of P3 gamut, not displayable on most screens as of 2019</div>
 		</label>
 
+		<label class="[if(!isLCH_within_r2020(lightness, chroma, hue), 'out-of-gamut')]">Rec.2020 Color
+			<input property="colorP3" value="[LCH_to_r2020_string(lightness, chroma, hue)]" readonly />
+			<div class="out-of-gamut-warning">Out of Rec.2020 gamut, are you kidding!!</div>
+		</label>
+
 		<section>
 			<h2>
 				Saved colors

--- a/lch/lch.js
+++ b/lch/lch.js
@@ -1,3 +1,9 @@
+function LCH_to_r2020_string(l, c, h, a = 100) {
+	return "color(rec2020 " + LCH_to_r2020([+l, +c, +h]).map(x => {
+		x = Math.round(x * 10000)/10000;
+		return x;
+	}).join(" ") + (a < 100? `/ ${a}%` : "") + ")"
+}
 
 function LCH_to_P3_string(l, c, h, a = 100) {
 	return "color(display-p3 " + LCH_to_P3([+l, +c, +h]).map(x => {
@@ -26,6 +32,12 @@ function isLCH_within_sRGB(l, c, h) {
 
 function isLCH_within_P3(l, c, h) {
 	var rgb = LCH_to_P3([+l, +c, +h]);
+	const ε = .000005;
+	return rgb.reduce((a, b) => a && b >= (0 - ε) && b <= (1 + ε), true);
+}
+
+function isLCH_within_r2020(l, c, h) {
+	var rgb = LCH_to_r2020([+l, +c, +h]);
 	const ε = .000005;
 	return rgb.reduce((a, b) => a && b >= (0 - ε) && b <= (1 + ε), true);
 }


### PR DESCRIPTION
In addition to the sRGB and display-p3 values, also display rec.2020 which is the colorspace for broadcast 4k HDR content (Netflix, Disney, etc). If the color is outside rec.2020 then seriously, nothing is going to display that color anytime this decade.