### PR TITLE
Gamut-correction for p3 and color-stops

### DIFF
--- a/lch/index.html
+++ b/lch/index.html
@@ -42,7 +42,7 @@
 			<input type="number" property="alphaNumber" mv-default="[alpha]" style="--percentage: [alpha / 100]" max="100" />
 		</label>
 	<label>CSS Color <span class="decimals">(<span property="decimals" mv-mode="edit" mv-edit-type="number" mv-edit-min="0" mv-edit-max="20">3</span> decimals)</span>
-		<input property="color" value="lch([round(lightness, decimals)]% [round(chroma, decimals)] [round(hue, decimals)])" readonly />
+		<input property="color" value="lch([round(lightness, decimals)]% [round(chroma, decimals)] [round(hue, decimals)][alpha_to_string(alpha)])" readonly />
 	</label>
 	<label class="[if(!isLCH_within_sRGB(lightness, chroma, hue), 'out-of-gamut')]" style="--color: [colorRGB]">
 		<abbr>sRGB</abbr> Color <span mv-if="!supportsP3" title="This is what is currently displayed">👁</span>
@@ -54,12 +54,12 @@
 		<summary>Advanced</summary>
 		<label class="[if(!isLCH_within_P3(lightness, chroma, hue), 'out-of-gamut')]">
 			P3 Color <span mv-if="supportsP3" title="This is what is currently displayed">👁</span>
-			<input property="colorP3" value="[LCH_to_P3_string(lightness, chroma, hue)]" readonly />
-			<div class="out-of-gamut-warning">Out of P3 gamut, not displayable on most screens as of 2019</div>
+			<input property="colorP3" value="[LCH_to_P3_string(lightness, chroma, hue, alpha, true)]" readonly />
+			<div class="out-of-gamut-warning">Color is actually [LCH_to_P3_string(lightness, chroma, hue, alpha)], which is not displayable on most screens as of 2019; auto-corrected to P3 boundary.</div>
 		</label>
 
 		<label class="[if(!isLCH_within_r2020(lightness, chroma, hue), 'out-of-gamut')]">Rec.2020 Color
-			<input property="colorR2020" value="[LCH_to_r2020_string(lightness, chroma, hue)]" readonly />
+			<input property="colorR2020" value="[LCH_to_r2020_string(lightness, chroma, hue, alpha)]" readonly />
 			<div class="out-of-gamut-warning">Out of Rec.2020 gamut, are you kidding?!</div>
 		</label>
 

--- a/lch/lch.js
+++ b/lch/lch.js
@@ -1,10 +1,14 @@
 const supportsP3 = self.CSS && CSS.supports("color", "color(display-p3 0 1 0)");
 
+function alpha_to_string(a = 100) {
+	return (a < 100? ` / ${a}%` : "");
+}
+
 function LCH_to_r2020_string(l, c, h, a = 100) {
 	return "color(rec2020 " + LCH_to_r2020([+l, +c, +h]).map(x => {
 		x = Math.round(x * 10000)/10000;
 		return x;
-	}).join(" ") + (a < 100? `/ ${a}%` : "") + ")";
+	}).join(" ") + alpha_to_string(a) + ")";
 }
 
 function LCH_to_P3_string(l, c, h, a = 100, forceInGamut = false) {
@@ -15,7 +19,7 @@ function LCH_to_P3_string(l, c, h, a = 100, forceInGamut = false) {
 	return "color(display-p3 " + LCH_to_P3([+l, +c, +h]).map(x => {
 		x = Math.round(x * 10000)/10000;
 		return x;
-	}).join(" ") + (a < 100? `/ ${a}%` : "") + ")";
+	}).join(" ") + alpha_to_string(a) + ")";
 }
 
 function LCH_to_sRGB_string(l, c, h, a = 100, forceInGamut = false) {
@@ -25,7 +29,7 @@ function LCH_to_sRGB_string(l, c, h, a = 100, forceInGamut = false) {
 
 	return "rgb(" + LCH_to_sRGB([+l, +c, +h]).map(x => {
 		return Math.round(x * 10000)/100 + "%";
-	}).join(" ") + (a < 100? ` / ${a}%` : "") + ")";
+	}).join(" ") + alpha_to_string(a) + ")";
 }
 
 function force_into_gamut(l, c, h, isLCH_within) {

--- a/lch/lch.js
+++ b/lch/lch.js
@@ -7,7 +7,11 @@ function LCH_to_r2020_string(l, c, h, a = 100) {
 	}).join(" ") + (a < 100? `/ ${a}%` : "") + ")";
 }
 
-function LCH_to_P3_string(l, c, h, a = 100) {
+function LCH_to_P3_string(l, c, h, a = 100, forceInGamut = false) {
+	if (forceInGamut) {
+		[l, c, h] = force_into_gamut(l, c, h, isLCH_within_P3);
+	}
+
 	return "color(display-p3 " + LCH_to_P3([+l, +c, +h]).map(x => {
 		x = Math.round(x * 10000)/10000;
 		return x;
@@ -16,7 +20,7 @@ function LCH_to_P3_string(l, c, h, a = 100) {
 
 function LCH_to_sRGB_string(l, c, h, a = 100, forceInGamut = false) {
 	if (forceInGamut) {
-		[l, c, h] = force_into_sRGB_gamut(l, c, h);
+		[l, c, h] = force_into_gamut(l, c, h, isLCH_within_sRGB);
 	}
 
 	return "rgb(" + LCH_to_sRGB([+l, +c, +h]).map(x => {
@@ -24,12 +28,12 @@ function LCH_to_sRGB_string(l, c, h, a = 100, forceInGamut = false) {
 	}).join(" ") + (a < 100? ` / ${a}%` : "") + ")";
 }
 
-function force_into_sRGB_gamut(l, c, h) {
+function force_into_gamut(l, c, h, isLCH_within) {
 	// Moves an lch color into the sRGB gamut
 	// by holding the l and h steady,
 	// and adjusting the c via binary-search
 	// until the color is on the sRGB boundary.
-	if (isLCH_within_sRGB(l, c, h)) {
+	if (isLCH_within(l, c, h)) {
 		return [l, c, h];
 	}
 
@@ -40,7 +44,7 @@ function force_into_sRGB_gamut(l, c, h) {
 
 	// .0001 chosen fairly arbitrarily as "close enough"
 	while (hiC - loC > ε) {
-		if (isLCH_within_sRGB(l, c, h)) {
+		if (isLCH_within(l, c, h)) {
 			loC = c;
 		}
 		else {
@@ -74,7 +78,7 @@ function isLCH_within_r2020(l, c, h) {
 // (we need to use more to emulate proper interpolation)
 function slider_stops(range, l, c, h, a, index) {
 	return range.map(x => {
-		args = [l, c, h, a];
+		args = [l, c, h, a, true];
 		args[index] = x;
 		var LCH_to_string = supportsP3? LCH_to_P3_string : LCH_to_sRGB_string;
 		return LCH_to_string(...args);


### PR DESCRIPTION
Fixes #7 
Fixes #4

- `force_into_gamut` accepts functions to use for checking gamut
- `LCH_to_P3_string` accepts a `forceInGamut` argument (default `false`)
- `slider_stops` now calls both p3 & sRGB string functions with `forceInGamut = true`
- I added alpha values where they were missing, since that was conflicting with my other updates