### PR TITLE
Add import/export and download

### DIFF
--- a/lch/download.js
+++ b/lch/download.js
@@ -1,0 +1,40 @@
+// Custom Download format based on: https://github.com/LeaVerou/css.land/issues/11
+function download(colors, decimals) {
+    // Build an array of colors with all color formats displayed on screen
+    const round = Mavo.Functions.round;
+    const exportColors = [];
+    for (let color of colors) {
+        exportColors.push({
+            name: color.name.valueOf(),
+            lch: `lch(${round(color.lightness, decimals)}% ${round(color.chroma, decimals)} ${round(color.hue, decimals)}${alpha_to_string(color.alpha)})`,
+            rgb: LCH_to_sRGB_string(color.lightness, color.chroma, color.hue, color.alpha, true),
+            p3: LCH_to_P3_string(color.lightness, color.chroma, color.hue, color.alpha, true),
+            rec2020: LCH_to_r2020_string(color.lightness, color.chroma, color.hue, color.alpha),
+            warnings: {
+                rgb: (isLCH_within_sRGB(color.lightness, color.chroma, color.hue) ? null : `Color is actually [${LCH_to_sRGB_string(color.lightness, color.chroma, color.hue, color.alpha)}], which is out of sRGB gamut; auto-corrected to sRGB boundary.`),
+                p3: (isLCH_within_P3(color.lightness, color.chroma, color.hue) ? null : `Color is actually [${LCH_to_P3_string(color.lightness, color.chroma, color.hue, color.alpha)}], which is not displayable on most screens as of 2019; auto-corrected to P3 boundary.`),
+                rec2020: (isLCH_within_r2020(color.lightness, color.chroma, color.hue) ? null : "Out of Rec.2020 gamut, are you kidding?!"),
+            },
+        });
+    }
+
+    // Export JSON file by creating a hidden download link and clicking on it.
+    // The human-friendly colors are saved in the property `downloadColors`.
+    // All other data from the app is included so that if a user uses the
+    // import feature all properties populate as expected. Something to be
+    // aware of is additional color changes will no be reflected in `downloadColors`
+    // if using the standard export feature and not clicking the download button,
+    // however the download button is in the advanced section anyways.
+    const appName = document.querySelector("[mv-app]").getAttribute("mv-app");
+    const fileName = appName + ".json";
+    const json = Mavo.toJSON(Object.assign({ downloadColors: exportColors }, Mavo.all[appName].getData()));
+    const blob = new Blob([json], { type: "application/json; charset=UTF-8;" });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    link.setAttribute("href", url);
+    link.setAttribute("download", fileName);
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}

--- a/lch/index.html
+++ b/lch/index.html
@@ -14,11 +14,11 @@
 <body>
 	<main mv-storage="local" mv-app="lchPicker" mv-autosave style="--color: [if(supportsP3, colorP3, colorRGB)]"
 	mv-init='data:application/json,{"lightness": 50, "chroma": 50, "hue": 50, "alpha": 100}'
-	class="[if(showAdvanced, 'show-advanced')]" mv-mode="read">
+	class="[if(showAdvanced, 'show-advanced')]" mv-mode="read" mv-bar="with import export">
 		<meta property="supportsP3" content='[self.CSS && CSS.supports("color", "color(display-p3 0 1 0)")]'>
 		<h1>
 			LCH Colour Picker
-			<button mv-action="set(lchPicker, CSS_color_to_LCH())">Import…</button>
+			<button mv-action="set(lchPicker, CSS_color_to_LCH())">Enter CSS Color…</button>
 			<span class="name" hidden>[LCH_name(lightness, chroma, hue)]</span>
 		</h1>
 		<label class="color-slider-label">Lightness (0-100)
@@ -67,6 +67,7 @@
 			<h2>
 				Saved colors
 				<button mv-action="add(group(lightness: lightness, chroma: chroma, hue: hue, alpha: alpha), storedColor)">+ Add current</button>
+				<button mv-action="download(storedColor, decimals)" class="download" mv-if="count(storedColor) > 0">&#x2193; Download</button>
 				<button mv-action="clear(storedColor)" class="clear" mv-if="count(storedColor) > 0">&times; Clear All</button>
 			</h2>
 			<div id="saved">
@@ -104,6 +105,7 @@
 </main>
 
 <script src="lch.js"></script>
+<script src="download.js"></script>
 
 </body>
 </html>

--- a/lch/style.css
+++ b/lch/style.css
@@ -275,11 +275,13 @@ h2 {
 			background: rgba(0,0,0,.25);
 		}
 
-		h2 .clear {
+		h2 .clear,
+		h2 .download {
 			margin-left: auto;
 		}
 
-		h2 .clear:hover {
+		h2 .clear:hover,
+		h2 .download:hover {
 			background: #c00;
 			color: white;
 		}


### PR DESCRIPTION
I've added the following UI features based on Issue https://github.com/LeaVerou/css.land/issues/11

* Add support for built-in Mavo UI bar with `import` and `export`
* Renamed the existing `Import…` as `Enter CSS Color…`. Reason being is from a UX perspective having two import buttons would be confusing and `Enter CSS Color` seems clear.
* Add a custom `download` function in a new JavaScript file that is based on the human-friendly format of the original issue; detailed features:
  * The download colors are specified in property `downloadColors`.
  * A `warnings` property is added for each color and contains `null` for valid colors or the message that would be displayed on screen.
  * The download format also includes the full app model so that if a user tries to import the file it behaves as expected and imports all their settings.

**Here is what the changes look like:**

![image](https://user-images.githubusercontent.com/57777521/92667995-63ca4900-f2c2-11ea-8283-8c1ea85d18e7.png)

**Add the download file:**

![image](https://user-images.githubusercontent.com/57777521/92668042-8cead980-f2c2-11ea-9a71-9c431d1aebd6.png)

