### PR TITLE
Add sRGB hex string output

### DIFF
--- a/lch/index.html
+++ b/lch/index.html
@@ -49,6 +49,11 @@
 		<input property="colorRGB" value="[LCH_to_sRGB_string(lightness, chroma, hue, alpha, true)]" readonly />
 		<div class="out-of-gamut-warning">Color is actually [LCH_to_sRGB_string(lightness, chroma, hue, alpha)], which is out of sRGB gamut; auto-corrected to sRGB boundary.</div>
 	</label>
+	<label class="[if(!isLCH_within_sRGB(lightness, chroma, hue), 'out-of-gamut')]" style="--color: [colorRGB]">
+		<abbr>sRGB</abbr> Color (Hex) <span mv-if="!supportsP3" title="This is what is currently displayed">👁</span>
+		<input property="colorRGBhex" value="[LCH_to_sRGB_hex_string(lightness, chroma, hue, alpha, true)]" readonly />
+		<div class="out-of-gamut-warning">Color is actually [LCH_to_sRGB_hex_string(lightness, chroma, hue, alpha)], which is out of sRGB gamut; auto-corrected to sRGB boundary.</div>
+	</label>
 
 	<details mv-attribute="open" property="showAdvanced">
 		<summary>Advanced</summary>

--- a/lch/lch.js
+++ b/lch/lch.js
@@ -32,6 +32,17 @@ function LCH_to_sRGB_string(l, c, h, a = 100, forceInGamut = false) {
 	}).join(" ") + alpha_to_string(a) + ")";
 }
 
+function LCH_to_sRGB_hex_string(l, c, h, a = 100, forceInGamut = false) {
+	if (forceInGamut) {
+		[l, c, h] = force_into_gamut(l, c, h, isLCH_within_sRGB);
+	}
+
+	return "#" + LCH_to_sRGB([+l, +c, +h]).map(x => {
+		return Math.round(x * 255).toString(16).padStart(2, "0");
+	}).join("") +
+	(a < 100 ? Math.round(a / 100 * 255).toString(16).padStart(2, "0") : "");
+}
+
 function force_into_gamut(l, c, h, isLCH_within) {
 	// Moves an lch color into the sRGB gamut
 	// by holding the l and h steady,


### PR DESCRIPTION
I’ve been using this color picker since I read your article on LCH coming to CSS. This tool has helped me in my projects, but I often find myself converting it to hex format when I need to support older browsers or paste the color into a design tool like Sketch. I added a simple hex output based on the sRGB output.